### PR TITLE
fix #12: error (document.body === null)

### DIFF
--- a/chrome-extension/content_script.js
+++ b/chrome-extension/content_script.js
@@ -1,5 +1,5 @@
 
-document.body.addEventListener('click', evt => {
+window.addEventListener('click', evt => {
 	// ユーザーの操作によるイベントならisTrusted == true
 	// If event is fired by user's operation then isTrusted == true.
 	// Chrome 46.0～


### PR DESCRIPTION
fix #12 

Since it is thought that window is never null, change the click judgment from document.body to window.

I could not reproduce that document.body is null when content_script is executed.
Therefore, it has not been confirmed whether the problem has been solved.