### PR TITLE
fix: to work with chrome118(Add permissions for file:///*)

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -12,6 +12,7 @@
 		"scripting"
 	],
 	"host_permissions": [
+		"file:///*",
 		"*://*/*"
 	],
 	"background": {


### PR DESCRIPTION
Add permissions requested by the extension so that users can take countermeasures.

⚠️  User interaction required

## Reference
- [What's new in Chrome extensions - Chrome for Developers](https://developer.chrome.com/docs/extensions/whatsnew/#changes-to-file-scheme)
    > **Chrome 118: Changes to opening file: scheme URLs**
    > Beginning in Chrome 118, extensions will need the "Allow access to file URLs" setting enabled from the chrome://extensions page to open file:// scheme URLs using the [Tabs](https://developer.chrome.com/docs/extensions/reference/tabs/) or [Windows](https://developer.chrome.com/docs/extensions/reference/windows/) APIs.
- [Restricting use of file: URLs in tabs and windows APIs](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/ZtCvVISQU54/m/tOjjlzkfAgAJ?pli=1)
- [**Inconsistency: Navigation to file:// URLs using tabs and windows APIs**](https://togithub.com/w3c/webextensions/issues/426) `w3c/webextensions#426`


## Issue
- https://github.com/tksugimoto/chrome-extension_open-local-file-link/issues/24

## Future tasks (other PR)
- [ ] Add a mechanism to notify the user if the "Allow access to file URLs" setting is not enabled.