### PR TITLE
allow to work on shadow root

### DIFF
--- a/chrome-extension/content_script.js
+++ b/chrome-extension/content_script.js
@@ -5,7 +5,7 @@ if (!window.alreadyExecuted) window.addEventListener('click', evt => {
 	// Chrome 46.0～
 	// https://developer.mozilla.org/ja/docs/Web/API/Event/isTrusted
 	if (!evt.isTrusted) return;
-	let target = evt.target;
+	let target = evt.composedPath()[0];
 	while (target && target.tagName.toLowerCase() !== 'a' && target.tagName.toLowerCase() !== 'area') {
 		target = target.parentElement;
 	}


### PR DESCRIPTION
used event composed path instead of target.
In a shadow root  the target will point to the element hosting the shadow root.
https://github.com/tksugimoto/chrome-extension_open-local-file-link/issues/32